### PR TITLE
[READY] - Updating Centralized-Logging Module

### DIFF
--- a/modules/centralized_logging/README.md
+++ b/modules/centralized_logging/README.md
@@ -1,0 +1,73 @@
+<!-- BEGIN_TF_DOCS -->
+## Centralized-Logging Module
+
+This module creates resources that will forward CloudWatch log group logs in an account to a central s3 bucket via Kinesis Firehose.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.3.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.30.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.30.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_event_rule.cloudwatch_log_group_create](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_rule.lambda_cron](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_target.cloudwatch_log_group_create](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_event_target.lambda_cron](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_log_group.firehose_error_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_group.lambda_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_stream.firehose_error_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_stream) | resource |
+| [aws_cloudwatch_metric_alarm.lambda_cloudwatch_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_iam_policy.cloudwatch_logs_kinesis_firehose_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.kinesis_firehose_s3_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.lambda_cloudwatch_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.cloudwatch_logs_kinesis_firehose_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.kinesis_firehose_s3_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.lambda_cloudwatch_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.cloudwatch_logs_kinesis_firehose_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.kinesis_firehose_s3_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.lambda_cloudwatch_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_kinesis_firehose_delivery_stream.cloudwatch_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kinesis_firehose_delivery_stream) | resource |
+| [aws_lambda_function.cloudwatch_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_permission.cloudwatch_lambda_cron](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [aws_lambda_permission.cloudwatch_log_create](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [aws_sns_topic.lambda_cloudwatch_logging_errors](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.cloudwatch_logs_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.cloudwatch_logs_kinesis_firehose_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.kinesis_firehose_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.kinesis_firehose_s3_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.lambda_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.lambda_cloudwatch_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cloudtrail_log_group_name"></a> [cloudtrail\_log\_group\_name](#input\_cloudtrail\_log\_group\_name) | Name of log group that a regional cloudtrail writes to | `string` | `"cloudtrail"` | no |
+| <a name="input_cloudwatch_schedule_expression"></a> [cloudwatch\_schedule\_expression](#input\_cloudwatch\_schedule\_expression) | CloudWatch event rule schedule expression that determines when the centralized-logging lambda will run | `string` | `"cron(0 0 * * ? *)"` | no |
+| <a name="input_env"></a> [env](#input\_env) | Name of the environment | `string` | `"dev"` | no |
+| <a name="input_firehose_log_group_name"></a> [firehose\_log\_group\_name](#input\_firehose\_log\_group\_name) | Name of log group that the firehose delivery stream will log errors to | `string` | `""` | no |
+| <a name="input_firehose_log_group_retention"></a> [firehose\_log\_group\_retention](#input\_firehose\_log\_group\_retention) | Number of days to retain logs for the firehose error log group | `number` | `180` | no |
+| <a name="input_lambda_config"></a> [lambda\_config](#input\_lambda\_config) | Map of lambda configuration options | `object{}` See variables.tf for attributes | n/a | yes |
+| <a name="input_lambda_log_group_name"></a> [lambda\_log\_group\_name](#input\_lambda\_log\_group\_name) | Name of log group that the central logging lambda will log to | `string` | `""` | no |
+| <a name="input_lambda_log_group_retention"></a> [lambda\_log\_group\_retention](#input\_lambda\_log\_group\_retention) | Number of days to retain logs for the lambda log group | `number` | `180` | no |
+| <a name="input_s3_logging_bucket"></a> [s3\_logging\_bucket](#input\_s3\_logging\_bucket) | Name of s3 logging bucket | `string` | n/a | yes |
+| <a name="input_s3_logging_bucket_kms_key_arn"></a> [s3\_logging\_bucket\_kms\_key\_arn](#input\_s3\_logging\_bucket\_kms\_key\_arn) | ARN of KMS key that encrypts central logging bucket (optional) | `string` | `""` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Map of tags you'd like applied to taggable resources in this module | `map(string)` | `{}` | no |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/modules/centralized_logging/cloudwatch.tf
+++ b/modules/centralized_logging/cloudwatch.tf
@@ -51,13 +51,25 @@ resource "aws_cloudwatch_event_rule" "cloudwatch_log_group_create" {
 EOF
 }
 
+resource "aws_cloudwatch_event_rule" "lambda_cron" {
+  name                = "lambda-centralized-logging-cron-${local.region}"
+  description         = "Periodic trigger for the centralized-logging lambda"
+  schedule_expression = var.cloudwatch_schedule_expression
+}
+
 ##########
 # Cloudwatch Event Target
 ##########
 
 resource "aws_cloudwatch_event_target" "cloudwatch_log_group_create" {
-  target_id = "cloudwatch-log-group-creation"
+  target_id = "cloudwatch-log-group-creation-${local.region}"
   rule      = aws_cloudwatch_event_rule.cloudwatch_log_group_create.name
+  arn       = aws_lambda_function.cloudwatch_logging.arn
+}
+
+resource "aws_cloudwatch_event_target" "lambda_cron" {
+  target_id = "lambda-centralized-logging-cron-${local.region}"
+  rule      = aws_cloudwatch_event_rule.lambda_cron.name
   arn       = aws_lambda_function.cloudwatch_logging.arn
 }
 

--- a/modules/centralized_logging/data.tf
+++ b/modules/centralized_logging/data.tf
@@ -2,6 +2,7 @@ data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
 locals {
+  account_id              = data.aws_caller_identity.current.account_id
   region                  = data.aws_region.current.name
   tags                    = var.tags
   firehose_log_group_name = var.firehose_log_group_name == "" ? "/aws/kinesisfirehose/${local.region}-cloudwatch-logs" : var.firehose_log_group_name

--- a/modules/centralized_logging/data.tf
+++ b/modules/centralized_logging/data.tf
@@ -2,11 +2,13 @@ data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
 locals {
-  account_id              = data.aws_caller_identity.current.account_id
-  region                  = data.aws_region.current.name
-  tags                    = var.tags
-  firehose_log_group_name = var.firehose_log_group_name == "" ? "/aws/kinesisfirehose/${local.region}-cloudwatch-logs" : var.firehose_log_group_name
-  lambda_function_name    = var.lambda_config.function_name == "" ? "centralized-logging" : var.lambda_config.function_name
-  lambda_log_group_name   = var.lambda_log_group_name == "" ? "/aws/lambda/${local.lambda_function_name}" : var.firehose_log_group_name
+  account_id                         = data.aws_caller_identity.current.account_id
+  region                             = data.aws_region.current.name
+  tags                               = var.tags
+  firehose_delivery_stream_s3_prefix = var.firehose_log_group_name == "" ? "${var.env}/${local.account_id}/cloudwatch-logs/" : var.firehose_delivery_stream_s3_prefix
+  firehose_log_group_name            = var.firehose_log_group_name == "" ? "/aws/kinesisfirehose/${local.region}-cloudwatch-logs" : var.firehose_log_group_name
+
+  lambda_function_name  = var.lambda_config.function_name == "" ? "centralized-logging" : var.lambda_config.function_name
+  lambda_log_group_name = var.lambda_log_group_name == "" ? "/aws/lambda/${local.lambda_function_name}" : var.firehose_log_group_name
 
 }

--- a/modules/centralized_logging/iam.tf
+++ b/modules/centralized_logging/iam.tf
@@ -52,6 +52,11 @@ data "aws_iam_policy_document" "kinesis_firehose_assume_role" {
       identifiers = ["firehose.amazonaws.com"]
     }
     actions = ["sts:AssumeRole"]
+    condition {
+      test     = "StringEquals"
+      variable = "sts:ExternalId"
+      values   = [local.account_id]
+    }
   }
 }
 
@@ -107,10 +112,16 @@ data "aws_iam_policy_document" "kinesis_firehose_s3_logging" {
 
 data "aws_iam_policy_document" "lambda_assume_role" {
   statement {
+    sid     = "LambdaAssumeRole"
     actions = ["sts:AssumeRole"]
     principals {
       type        = "Service"
       identifiers = ["lambda.amazonaws.com"]
+    }
+    condition {
+      test     = "StringLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:lambda:${local.region}:${local.account_id}:*"]
     }
   }
 }

--- a/modules/centralized_logging/iam.tf
+++ b/modules/centralized_logging/iam.tf
@@ -171,6 +171,7 @@ resource "aws_iam_role" "kinesis_firehose_s3_logging" {
 resource "aws_iam_role" "lambda_cloudwatch_logging" {
   name               = "lambda-cloudwatch-logging-${local.region}"
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+  description        = "IAM role used by centralized-logging lambda"
 }
 
 ##########

--- a/modules/centralized_logging/iam.tf
+++ b/modules/centralized_logging/iam.tf
@@ -12,9 +12,14 @@ data "aws_iam_policy_document" "cloudwatch_logs_assume_role" {
     effect = "Allow"
     principals {
       type        = "Service"
-      identifiers = ["logs.amazonaws.com"]
+      identifiers = ["logs.${local.region}.amazonaws.com"]
     }
     actions = ["sts:AssumeRole"]
+    condition {
+      test     = "StringLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:logs:${local.region}:${local.account_id}:*"]
+    }
   }
 }
 
@@ -25,6 +30,7 @@ data "aws_iam_policy_document" "cloudwatch_logs_kinesis_firehose_logging" {
     sid    = "CloudWatchWriteKinesisDataFirehose"
     effect = "Allow"
     actions = [
+      "firehose:DescribeDeliveryStream",
       "firehose:PutRecord",
       "firehose:PutRecordBatch"
     ]
@@ -147,7 +153,7 @@ data "aws_iam_policy_document" "lambda_cloudwatch_logging" {
 ##### CloudWatch Logs
 
 resource "aws_iam_role" "cloudwatch_logs_kinesis_firehose_logging" {
-  name               = "cloudwatch-logs-kinesis-firehose-logging-${data.aws_region.current.name}"
+  name               = "cloudwatch-logs-kinesis-firehose-logging-${local.region}"
   assume_role_policy = data.aws_iam_policy_document.cloudwatch_logs_assume_role.json
   description        = "IAM role used by CloudWatch logs subscription filter to foward logs to Kinesis Data Firehose Delivery stream"
 }
@@ -155,7 +161,7 @@ resource "aws_iam_role" "cloudwatch_logs_kinesis_firehose_logging" {
 ##### Kinesis Data Firehose
 
 resource "aws_iam_role" "kinesis_firehose_s3_logging" {
-  name               = "kinesis-firehose-s3-logging-${data.aws_region.current.name}"
+  name               = "kinesis-firehose-s3-logging-${local.region}"
   assume_role_policy = data.aws_iam_policy_document.kinesis_firehose_assume_role.json
   description        = "IAM role used by Kinesis Firehose delivery stream to push objects to the s3 logging bucket"
 }
@@ -163,7 +169,7 @@ resource "aws_iam_role" "kinesis_firehose_s3_logging" {
 #### Lambda
 
 resource "aws_iam_role" "lambda_cloudwatch_logging" {
-  name               = "lambda-cloudwatch-logging-${data.aws_region.current.name}"
+  name               = "lambda-cloudwatch-logging-${local.region}"
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
 }
 
@@ -174,7 +180,7 @@ resource "aws_iam_role" "lambda_cloudwatch_logging" {
 ##### Cloudwatch Logs
 
 resource "aws_iam_policy" "cloudwatch_logs_kinesis_firehose_logging" {
-  name        = "cloudwatch-logs-kinesis-rw-${data.aws_region.current.name}"
+  name        = "cloudwatch-logs-kinesis-rw-${local.region}"
   description = "Allows Cloudwatch logs to write to a Kinesis Firehose Delivery stream"
   policy      = data.aws_iam_policy_document.cloudwatch_logs_kinesis_firehose_logging.json
 }
@@ -182,7 +188,7 @@ resource "aws_iam_policy" "cloudwatch_logs_kinesis_firehose_logging" {
 ##### Kinesis Data Firehose
 
 resource "aws_iam_policy" "kinesis_firehose_s3_logging" {
-  name        = "kinesis-firehose-s3-logging-${data.aws_region.current.name}"
+  name        = "kinesis-firehose-s3-logging-${local.region}"
   description = "Allows Kinesis Data Firehose to read/write logs to s3 logging bucket"
   policy      = data.aws_iam_policy_document.kinesis_firehose_s3_logging.json
 }
@@ -190,7 +196,7 @@ resource "aws_iam_policy" "kinesis_firehose_s3_logging" {
 #### Lambda
 
 resource "aws_iam_policy" "lambda_cloudwatch_logging" {
-  name        = "lambda-cloudwatch-logging-${data.aws_region.current.name}"
+  name        = "lambda-cloudwatch-logging-${local.region}"
   description = "Allows AWS lambda to create cloduwatch subscription filters, log to cloudwatch and read Firehose delivery stream info"
   policy      = data.aws_iam_policy_document.lambda_cloudwatch_logging.json
 }

--- a/modules/centralized_logging/kinesis-firehose.tf
+++ b/modules/centralized_logging/kinesis-firehose.tf
@@ -1,16 +1,19 @@
 resource "aws_kinesis_firehose_delivery_stream" "cloudwatch_logs" {
-  name        = "cloudwatch-logs-${data.aws_region.current.name}"
+  name        = "cloudwatch-logs-${local.region}"
   destination = "extended_s3"
 
+
   extended_s3_configuration {
-    role_arn   = aws_iam_role.kinesis_firehose_s3_logging.arn
-    bucket_arn = "arn:aws:s3:::${var.s3_logging_bucket}"
-    prefix     = "${var.env}/${data.aws_caller_identity.current.account_id}/cloudwatch-logs/"
+    role_arn           = aws_iam_role.kinesis_firehose_s3_logging.arn
+    bucket_arn         = "arn:aws:s3:::${var.s3_logging_bucket}"
+    buffer_size        = var.firehose_delivery_stream_buffer_size
+    buffer_interval    = var.firehose_delivery_stream_buffer_interval
+    compression_format = var.firehose_delivery_stream_compression_format
+    prefix             = "${var.env}/${data.aws_caller_identity.current.account_id}/cloudwatch-logs/"
     cloudwatch_logging_options {
       enabled         = true
       log_group_name  = "/aws/kinesisfirehose/${local.region}-cloudwatch-logs"
       log_stream_name = "S3Delivery"
     }
-    compression_format = "GZIP" # Default is `UNCOMPRESSED` but we have proven the format is gz
   }
 }

--- a/modules/centralized_logging/kinesis-firehose.tf
+++ b/modules/centralized_logging/kinesis-firehose.tf
@@ -2,14 +2,13 @@ resource "aws_kinesis_firehose_delivery_stream" "cloudwatch_logs" {
   name        = "cloudwatch-logs-${local.region}"
   destination = "extended_s3"
 
-
   extended_s3_configuration {
     role_arn           = aws_iam_role.kinesis_firehose_s3_logging.arn
     bucket_arn         = "arn:aws:s3:::${var.s3_logging_bucket}"
     buffer_size        = var.firehose_delivery_stream_buffer_size
     buffer_interval    = var.firehose_delivery_stream_buffer_interval
     compression_format = var.firehose_delivery_stream_compression_format
-    prefix             = "${var.env}/${data.aws_caller_identity.current.account_id}/cloudwatch-logs/"
+    prefix             = local.firehose_delivery_stream_s3_prefix
     cloudwatch_logging_options {
       enabled         = true
       log_group_name  = "/aws/kinesisfirehose/${local.region}-cloudwatch-logs"

--- a/modules/centralized_logging/lambda.tf
+++ b/modules/centralized_logging/lambda.tf
@@ -39,3 +39,11 @@ resource "aws_lambda_permission" "cloudwatch_log_create" {
   principal     = "events.amazonaws.com"
   source_arn    = aws_cloudwatch_event_rule.cloudwatch_log_group_create.arn
 }
+
+resource "aws_lambda_permission" "cloudwatch_lambda_cron" {
+  statement_id  = "cloudwatch-lambda-cron"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.cloudwatch_logging.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.lambda_cron.arn
+}

--- a/modules/centralized_logging/outputs.tf
+++ b/modules/centralized_logging/outputs.tf
@@ -1,0 +1,19 @@
+output "cloudwatch_logs_kinesis_firehose_logging_role_arn" {
+  description = "ARN of IAM role used by CloudWatch logs subscription filter to forward logs to Kinesis Data Firhose Delivery stream"
+  value       = aws_iam_role.cloudwatch_logs_kinesis_firehose_logging.arn
+}
+
+output "kinesis_firehose_s3_logging_role_arn" {
+  description = "ARN of IAM role used by Kinesis Firehose delivery stream to push objects to the s3 logging bucket"
+  value       = aws_iam_role.kinesis_firehose_s3_logging.arn
+}
+
+output "lambda_cloudwatch_logging_role_arn" {
+  description = "ARN of IAM role used by centralized-logging lamdba"
+  value       = aws_iam_role.kinesis_firehose_s3_logging.arn
+}
+
+output "lambda_cloudwatch_logging_errors_sns_topic" {
+  description = "ARN of SNS topic for centralized-logging lambda errors"
+  value       = aws_sns_topic.lambda_cloudwatch_logging_errors.arn
+}

--- a/modules/centralized_logging/sns.tf
+++ b/modules/centralized_logging/sns.tf
@@ -1,4 +1,4 @@
 resource "aws_sns_topic" "lambda_cloudwatch_logging_errors" {
-  name         = "cloudwatch-logging-lambda-errors-${local.region}"
-  display_name = "cloudwatch-logging-lambda-errors-${local.region}"
+  name         = "centralized-logging-lambda-errors-${local.region}"
+  display_name = "centralized-logging-lambda-errors-${local.region}"
 }

--- a/modules/centralized_logging/variables.tf
+++ b/modules/centralized_logging/variables.tf
@@ -45,6 +45,15 @@ variable "firehose_delivery_stream_compression_format" {
   default     = "GZIP"
 }
 
+variable "firehose_delivery_stream_s3_prefix" {
+  description = <<EOT
+  (optional) : The 'YYYY/MM/DD/HH' time format prefix is automatically used for delivered S3 files. You can specify an extra prefix to be added in front of the time format prefix. Note that if the prefix ends with a slash, it appears as a folder in the S3 bucket. 
+  Default prefix defined in data.tf: '<env>/<account_id>/cloudwatch-logs/'
+  EOT
+  type        = string
+  default     = ""
+}
+
 variable "firehose_log_group_name" {
   description = "Name of log group that the firehose delivery stream will log errors to"
   type        = string

--- a/modules/centralized_logging/variables.tf
+++ b/modules/centralized_logging/variables.tf
@@ -42,7 +42,11 @@ variable "firehose_delivery_stream_buffer_interval" {
 variable "firehose_delivery_stream_compression_format" {
   description = "The compression format. Some options: 'UNCOMPRESSED', 'GZIP', 'ZIP', 'Snappy', 'HADOOP_SNAPPY'"
   type        = string
-  default     = "GZIP"
+  default     = "UNCOMPRESSED"
+  validation {
+    condition     = contains(["UNCOMPRESSED", "GZIP", "ZIP", "Snappy", "HADOOP_SNAPPY"], var.firehose_delivery_stream_compression_format)
+    error_message = "The compression format must be one of the following: 'UNCOMPRESSED', 'GZIP', 'ZIP', 'Snappy', 'HADOOP_SNAPPY'"
+  }
 }
 
 variable "firehose_delivery_stream_s3_prefix" {

--- a/modules/centralized_logging/variables.tf
+++ b/modules/centralized_logging/variables.tf
@@ -21,6 +21,30 @@ variable "cloudtrail_log_group_name" {
   default     = "cloudtrail"
 }
 
+variable "cloudwatch_schedule_expression" {
+  description = "CloudWatch event rule schedule expression that determines when the centralized-logging lambda will run"
+  type        = string
+  default     = "cron(0 0 * * ? *)"
+}
+
+variable "firehose_delivery_stream_buffer_size" {
+  description = "Buffer incoming data to the specified size, in MBs, before delivering it to the destination"
+  type        = number
+  default     = 5
+}
+
+variable "firehose_delivery_stream_buffer_interval" {
+  description = "Buffer incoming data to the specified size, in MBs, before delivering it to the destination"
+  type        = number
+  default     = 300
+}
+
+variable "firehose_delivery_stream_compression_format" {
+  description = "The compression format. Some options: 'UNCOMPRESSED', 'GZIP', 'ZIP', 'Snappy', 'HADOOP_SNAPPY'"
+  type        = string
+  default     = "GZIP"
+}
+
 variable "firehose_log_group_name" {
   description = "Name of log group that the firehose delivery stream will log errors to"
   type        = string

--- a/modules/centralized_logging/versions.tf
+++ b/modules/centralized_logging/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">=1.3.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.30.0"
+    }
+  }
+}


### PR DESCRIPTION
### Description

Pushing the following fixes/updates to the centralized-logging module:

* Fix IAM permission issue which was preventing cloudwatch from forwading logs to the firehose delivery stream
* Add cloudwatch event rule CRON that triggers the centralized-logging lambda periodically (needed for edge-case where log group is created before lambda exists).
* Add documentation for module.
* Add conditional for firehose compression format variable.